### PR TITLE
Attiva applicazione di test durante i test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
 addons:
   postgresql: "9.4"
 
+env:
+  - ENABLE_TEST_APPS=1
+
 cache: pip
 
 before_script:

--- a/jorvik/settings.py
+++ b/jorvik/settings.py
@@ -18,7 +18,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Elenca le applicazioni installate da abilitare
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -56,7 +56,7 @@ INSTALLED_APPS = (
     'centrale_operativa',
     'compressor',
     'segmenti',
-)
+]
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
@@ -232,3 +232,6 @@ BOOTSTRAP3 = {
         'inline': 'bootstrap3.renderers.InlineFieldRenderer',
     },
 }
+
+if os.environ.get('ENABLE_TEST_APPS', False):
+    INSTALLED_APPS.append('segmenti.segmenti_test')


### PR DESCRIPTION
Usa una variabile di ambiente per abilitare l'applicazione di test

Da riga di comando basta eseguire i test con ``ENABLE_TEST_APPS=1 ./manage.py test  ...``